### PR TITLE
Changed GetFirstFreeAddress to use POST

### DIFF
--- a/controllers/subnets/subnets.go
+++ b/controllers/subnets/subnets.go
@@ -143,7 +143,7 @@ func (c *Controller) GetSubnetsByCIDR(cidr string) (out []Subnet, err error) {
 // Note that marking a subnet as used does not prevent this function from
 // returning data.
 func (c *Controller) GetFirstFreeAddress(id int) (out string, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/subnets/%d/first_free/", id), &struct{}{}, &out)
+	err = c.SendRequest("POST", fmt.Sprintf("/subnets/%d/first_free/", id), &struct{}{}, &out)
 	return
 }
 


### PR DESCRIPTION
Changed method for first_free to POST to enable locking of the IP. This should resolve the issue with terraform assigning the same IP multiple times.