### PR TITLE
Expand Nameserver information

### DIFF
--- a/controllers/subnets/subnets.go
+++ b/controllers/subnets/subnets.go
@@ -43,6 +43,9 @@ type Subnet struct {
 	// The ID of the nameserver to attache the subnet to.
 	NameserverID int `json:"nameserverId,string,omitempty"`
 
+	// The ID and IPs of the nameservers for the subnet
+	Nameservers map[string]interface{} `json:"nameservers,omitempty"`
+
 	// true if the name should be displayed in listing instead of the subnet
 	// address.
 	ShowName phpipam.BoolIntString `json:"showName,omitempty"`

--- a/controllers/subnets/subnets_test.go
+++ b/controllers/subnets/subnets_test.go
@@ -77,6 +77,13 @@ const testGetSubnetByIDOutputJSON = `
     "DNSrecursive": "0",
     "DNSrecords": "0",
     "nameserverId": "0",
+    "nameservers": {
+        "id": "0",
+        "name": "mynameserver.example.com",
+        "namesrv1": "1.2.3.4",
+        "description": "a nameserver description",
+        "permissions": 1
+    },
     "scanAgent": null,
     "isFolder": "0",
     "isFull": "0",


### PR DESCRIPTION
This PR expands the nameserver details from the subnet information.

It will in turn allow this [Terraform provider](https://github.com/lord-kyron/terraform-provider-phpipam) to use the nameserver information when creating other resources.