### PR TITLE
enable the http client to pick up proxy from environment

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/imdario/mergo v0.0.0-20160517064435-50d4dbd4eb0e h1:zIX9lnwsSCcX3oc3J5w16I+3zmf6a+vdf80ygUqpah8=
+github.com/imdario/mergo v0.0.0-20160517064435-50d4dbd4eb0e/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/phpipam/request/request.go
+++ b/phpipam/request/request.go
@@ -134,6 +134,7 @@ func (r *Request) Send() error {
 	var err error
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: r.Session.Config.Insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	client := &http.Client{
 		Transport: tr,


### PR DESCRIPTION
This PR adds the ability to consume `http_proxy` environment variables and use this library through a corporate network that forces users to go through a proxy to reach external endpoints.