### PR TITLE
Adding option to search an ip with in a subnet

### DIFF
--- a/controllers/addresses/addresses.go
+++ b/controllers/addresses/addresses.go
@@ -112,6 +112,14 @@ func (c *Controller) GetAddressesByIP(ipaddr string) (out []Address, err error) 
 	return
 }
 
+// GetAddressesByIP searches for an address by its IP with in given subnet
+// When having multiple subnets with same ip range this will return the address in the given subnet
+// Those subnet may not talk to each other but still exist under on phpIPAM instance especially on ones migrated from previous versions 
+func (c *Controller) GetAddressesByIpInSubnet(ipaddr string,subnetID int) (out Address, err error) {
+	err = c.SendRequest("GET", fmt.Sprintf("/addresses/%s/%d", ipaddr,subnetID), &struct{}{}, &out)
+	return
+}
+
 // GetAddressCustomFieldsSchema GETs the custom fields for the addresses controller via
 // client.GetCustomFieldsSchema.
 func (c *Controller) GetAddressCustomFieldsSchema() (out map[string]phpipam.CustomField, err error) {

--- a/controllers/addresses/addresses_test.go
+++ b/controllers/addresses/addresses_test.go
@@ -127,6 +127,46 @@ const testGetAddressesByIPOutputJSON = `
 }
 `
 
+var testGetAddressesByIpInSubnetOutputExpected = Address{
+	ID:          11,
+	SubnetID:    3,
+	IPAddress:   "10.10.1.10",
+	Description: "foobar",
+	
+}
+
+const testGetAddressesByIpInSubnetOutputJSON = `
+{
+  "code": 200,
+  "success": true,
+  "data": 
+	{
+		"id": "11",
+		"subnetId": "3",
+		"ip": "10.10.1.10",
+		"is_gateway": null,
+		"description": "foobar",
+		"hostname": null,
+		"mac": null,
+		"owner": null,
+		"port": null,
+		"note": null,
+		"lastSeen": null,
+		"excludePing": null,
+		"PTRignore": null,
+		"PTR": "0",
+		"firewallAddressObject": null,
+		"editDate": null,
+		"links": [
+			{
+				"rel": "self",
+				"href": "/api/test/addresses/11/"
+			}
+		]
+    }
+}
+`
+
 var testGetAddressCustomFieldsSchemaExpected = map[string]phpipam.CustomField{
 	"CustomTestAddresses": phpipam.CustomField{
 		Name:    "CustomTestAddresses",
@@ -276,6 +316,25 @@ func TestGetAddressesByIP(t *testing.T) {
 		t.Fatalf("Expected %#v, got %#v", expected, actual)
 	}
 }
+
+func TestGetAddressesByIpInSubnet(t *testing.T) {
+	ts := httpOKTestServer(testGetAddressesByIpInSubnetOutputJSON)
+	defer ts.Close()
+	sess := fullSessionConfig()
+	sess.Config.Endpoint = ts.URL
+	client := NewController(sess)
+
+	expected := testGetAddressesByIpInSubnetOutputExpected
+	actual, err := client.GetAddressesByIpInSubnet("10.10.1.10/24",3)
+	if err != nil {
+		t.Fatalf("Bad: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected %#v, got %#v", expected, actual)
+	}
+}
+
 
 func TestGetAddressCustomFieldsSchema(t *testing.T) {
 	ts := httpOKTestServer(testGetAddressCustomFieldsSchemaJSON)


### PR DESCRIPTION
When having multiple subnets with the same ip range this will return the address in the given subnet. 
That subnet may not talk to each other but still exist under one phpIPAM instance, especially on ones migrated from previous versions or with ping autodetect that does not write to the right subnet
This pull request is needed to help terraform providers handle those older migrated phpIPAM and other less standard cases.
It will be used when the free address was reserved but in search gets multiple results from different subnets when in fact we know the exact subnet used.
