### PR TITLE
PHP8 compatibility

### DIFF
--- a/controllers/addresses/addresses.go
+++ b/controllers/addresses/addresses.go
@@ -11,12 +11,12 @@ import (
 )
 
 // Address represents an IP address resource within PHPIPAM.
-type Address struct {
+type AddressDTO struct {
 	// The ID of the IP address entry within PHPIPAM.
-	ID int `json:"id,string,omitempty"`
+	ID phpipam.JSONIntString `json:"id,omitempty"`
 
 	// The ID of the subnet that the address belongs to.
-	SubnetID int `json:"subnetId,string,omitempty"`
+	SubnetID phpipam.JSONIntString `json:"subnetId,omitempty"`
 
 	// The IP address, without a CIDR subnet mask.
 	IPAddress string `json:"ip,omitempty"`
@@ -37,16 +37,16 @@ type Address struct {
 	Owner string `json:"owner,omitempty"`
 
 	// The tag ID for the IP address.
-	Tag int `json:"tag,string,omitempty"`
+	Tag phpipam.JSONIntString `json:"tag,omitempty"`
 
 	// true if PTR records should not be created for this IP address.
 	PTRIgnore phpipam.BoolIntString `json:"PTRIgnore,omitempty"`
 
 	// The ID of a PowerDNS PTR record.
-	PTRRecordID int `json:"PTR,string,omitempty"`
+	PTRRecordID phpipam.JSONIntString `json:"PTR,omitempty"`
 
 	// An ID of a device that this address belongs to.
-	DeviceID int `json:"deviceId,string,omitempty"`
+	DeviceID phpipam.JSONIntString `json:"deviceId,omitempty"`
 
 	// A switchport number/label that this IP address belongs to.
 	Port string `json:"port,omitempty"`
@@ -72,6 +72,111 @@ type Address struct {
 	CustomFields map[string]interface{} `json:"custom_fields,omitempty"`
 }
 
+type Address struct {
+	// The ID of the IP address entry within PHPIPAM.
+	ID int `json:"id,omitempty"`
+
+	// The ID of the subnet that the address belongs to.
+	SubnetID int `json:"subnetId,omitempty"`
+
+	// The IP address, without a CIDR subnet mask.
+	IPAddress string `json:"ip,omitempty"`
+
+	// true if this IP address is a gateway address.
+	IsGateway phpipam.BoolIntString `json:"is_gateway,omitempty"`
+
+	// A detailed description of the IP address entry.
+	Description string `json:"description,omitempty"`
+
+	// A hostname for the IP address.
+	Hostname string `json:"hostname,omitempty"`
+
+	// The MAC address for the IP.
+	MACAddress string `json:"mac,omitempty"`
+
+	// The address owner (customer, hostname, application, etc).
+	Owner string `json:"owner,omitempty"`
+
+	// The tag ID for the IP address.
+	Tag int `json:"tag,omitempty"`
+
+	// true if PTR records should not be created for this IP address.
+	PTRIgnore phpipam.BoolIntString `json:"PTRIgnore,omitempty"`
+
+	// The ID of a PowerDNS PTR record.
+	PTRRecordID int `json:"PTR,omitempty"`
+
+	// An ID of a device that this address belongs to.
+	DeviceID int `json:"deviceId,omitempty"`
+
+	// A switchport number/label that this IP address belongs to.
+	Port string `json:"port,omitempty"`
+
+	// A note for this IP address, detailing state information not sutiable for
+	// entering in the description.
+	Note string `json:"note,omitempty"`
+
+	// A timestamp for when the address was last seen with ping.
+	LastSeen string `json:"lastSeen,omitempty"`
+
+	// true if you want to exclude this address from ping scans.
+	ExcludePing phpipam.BoolIntString `json:"excludePing,omitempty"`
+
+	// The date of the last edit to this resource.
+	EditDate string `json:"editDate,omitempty"`
+
+	// A map[string]interface{} of custom fields to set on the resource. Note
+	// that this functionality requires PHPIPAM 1.3 or higher with the "Nest
+	// custom fields" flag set on the specific API integration. If this is not
+	// enabled, this map will be nil on GETs and POSTs and PATCHes with this
+	// field set will fail. Use the explicit custom field functions instead.
+	CustomFields map[string]interface{} `json:"custom_fields,omitempty"`
+}
+
+func (a *Address) FromDTO(dto *AddressDTO) {
+	a.ID = int(dto.ID)
+	a.SubnetID = int(dto.SubnetID)
+	a.IPAddress = dto.IPAddress
+	a.IsGateway = dto.IsGateway
+	a.Description = dto.Description
+	a.Hostname = dto.Hostname
+	a.MACAddress = dto.MACAddress
+	a.Owner = dto.Owner
+	a.Tag = int(dto.Tag)
+	a.PTRIgnore = dto.PTRIgnore
+	a.PTRRecordID = int(dto.PTRRecordID)
+	a.DeviceID = int(dto.DeviceID)
+	a.Port = dto.Port
+	a.Note = dto.Note
+	a.LastSeen = dto.LastSeen
+	a.ExcludePing = dto.ExcludePing
+	a.EditDate = dto.EditDate
+	a.CustomFields = dto.CustomFields
+}
+
+func (a *Address) ToDTO() AddressDTO {
+	return AddressDTO{
+		ID:          phpipam.JSONIntString(a.ID),
+		SubnetID:    phpipam.JSONIntString(a.SubnetID),
+		IPAddress:   a.IPAddress,
+		IsGateway:   a.IsGateway,
+		Description: a.Description,
+		Hostname:    a.Hostname,
+		MACAddress:  a.MACAddress,
+		Owner:       a.Owner,
+		Tag:         phpipam.JSONIntString(a.Tag),
+		PTRIgnore:   a.PTRIgnore,
+		PTRRecordID: phpipam.JSONIntString(a.PTRRecordID),
+		DeviceID:    phpipam.JSONIntString(a.DeviceID),
+		Port:        a.Port,
+		Note:        a.Note,
+		LastSeen:    a.LastSeen,
+		ExcludePing: a.ExcludePing,
+		EditDate:    a.EditDate,
+		CustomFields: a.CustomFields,
+	}
+}
+
 // Controller is the base client for the Addresses controller.
 type Controller struct {
 	client.Client
@@ -87,19 +192,21 @@ func NewController(sess *session.Session) *Controller {
 
 // CreateAddress creates an address by sending a POST request.
 func (c *Controller) CreateAddress(in Address) (message string, err error) {
-	err = c.SendRequest("POST", "/addresses/", &in, &message)
+	err = c.SendRequest("POST", "/addresses/", in.ToDTO(), &message)
 	return
 }
 
 // CreateAddress creates a first free in subnet address by sending a POST request.
 func (c *Controller) CreateFirstFreeAddress(id int, in Address) (out string, err error) {
-        err = c.SendRequest("POST", fmt.Sprintf("/addresses/first_free/%d/", id), &in, &out)
+        err = c.SendRequest("POST", fmt.Sprintf("/addresses/first_free/%d/", id), in.ToDTO(), &out)
         return
 }
 
 // GetAddressByID GETs an address via its ID.
 func (c *Controller) GetAddressByID(id int) (out Address, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/addresses/%d/", id), &struct{}{}, &out)
+	var dto AddressDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/addresses/%d/", id), &struct{}{}, &dto)
+	out.FromDTO(&dto)
 	return
 }
 
@@ -108,7 +215,13 @@ func (c *Controller) GetAddressByID(id int) (out Address, err error) {
 // According to the spec, this can return multiple addresses, however it's not
 // entirely clear how to perform a search that would yield multiple results.
 func (c *Controller) GetAddressesByIP(ipaddr string) (out []Address, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/addresses/search/%s/", ipaddr), &struct{}{}, &out)
+	var dtos []AddressDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/addresses/search/%s/", ipaddr), &struct{}{}, &dtos)
+	for _, dto := range dtos {
+		var a Address
+		a.FromDTO(&dto)
+		out = append(out, a)
+	}
 	return
 }
 
@@ -116,7 +229,9 @@ func (c *Controller) GetAddressesByIP(ipaddr string) (out []Address, err error) 
 // When having multiple subnets with same ip range this will return the address in the given subnet
 // Those subnet may not talk to each other but still exist under on phpIPAM instance especially on ones migrated from previous versions 
 func (c *Controller) GetAddressesByIpInSubnet(ipaddr string,subnetID int) (out Address, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/addresses/%s/%d", ipaddr,subnetID), &struct{}{}, &out)
+	var dto AddressDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/addresses/%s/%d", ipaddr,subnetID), &struct{}{}, &dto)
+	out.FromDTO(&dto)
 	return
 }
 
@@ -136,7 +251,7 @@ func (c *Controller) GetAddressCustomFields(id int) (out map[string]interface{},
 
 // UpdateAddress updates an address by sending a PATCH request.
 func (c *Controller) UpdateAddress(in Address) (message string, err error) {
-	err = c.SendRequest("PATCH", "/addresses/", &in, &message)
+	err = c.SendRequest("PATCH", "/addresses/", in.ToDTO(), &message)
 	return
 }
 

--- a/controllers/l2domains/l2domains.go
+++ b/controllers/l2domains/l2domains.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 
 	"github.com/pavel-z1/phpipam-sdk-go/controllers/vlans"
-	//"github.com/pavel-z1/phpipam-sdk-go/phpipam"
+	"github.com/pavel-z1/phpipam-sdk-go/phpipam"
 	"github.com/pavel-z1/phpipam-sdk-go/phpipam/client"
 	"github.com/pavel-z1/phpipam-sdk-go/phpipam/session"
 )
 
 // L2Domain represents a PHPIPAM l2domain.
-type L2Domain struct {
+type L2DomainDTO struct {
 	// The L2 domain ID.
-	ID int `json:"id,string,omitempty"`
+	ID phpipam.JSONIntString `json:"id,omitempty"`
 
 	// The L2 domains name.
 	Name string `json:"name,omitempty"`
@@ -24,6 +24,36 @@ type L2Domain struct {
 
 	// The ID of the section's parent, if nested.
 	Sections string `json:"sections,omitempty"`
+}
+
+type L2Domain struct {
+	// The L2 domain ID.
+	ID int
+
+	// The L2 domains name.
+	Name string
+
+	// The l2domain's description.
+	Description string
+
+	// The ID of the section's parent, if nested.
+	Sections string
+}
+
+func (ld *L2Domain) ToDTO() L2DomainDTO {
+	return L2DomainDTO{
+		ID:          phpipam.JSONIntString(ld.ID),
+		Name:        ld.Name,
+		Description: ld.Description,
+		Sections:    ld.Sections,
+	}
+}
+
+func (ld *L2Domain) FromDTO(dto *L2DomainDTO) {
+	ld.ID = int(dto.ID)
+	ld.Name = dto.Name
+	ld.Description = dto.Description
+	ld.Sections = dto.Sections
 }
 
 // Controller is the base client for the L2Domains controller.
@@ -47,31 +77,45 @@ func (c *Controller) ListL2Domains() (out []L2Domain, err error) {
 
 // CreateL2Domain creates a l2domain by sending a POST request.
 func (c *Controller) CreateL2Domain(in L2Domain) (message string, err error) {
-	err = c.SendRequest("POST", "/l2domains/", &in, &message)
+	err = c.SendRequest("POST", "/l2domains/", in.ToDTO(), &message)
 	return
 }
 
 // GetL2DomainByID GETs a l2domain via its ID.
 func (c *Controller) GetL2DomainByID(id int) (out L2Domain, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/l2domains/%d/", id), &struct{}{}, &out)
+	var dto L2DomainDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/l2domains/%d/", id), &struct{}{}, &dto)
+	out.FromDTO(&dto)
 	return
 }
 
 // GetL2DomainByName GETs a l2domain via its name.
 func (c *Controller) GetL2DomainByName(name string) (out []L2Domain, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/l2domains/?filter_by=name&filter_value=%s", name), &struct{}{}, &out)
+	var dtos []L2DomainDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/l2domains/?filter_by=name&filter_value=%s", name), &struct{}{}, &dtos)
+	for _, dto := range dtos {
+		var l2Domain L2Domain
+		l2Domain.FromDTO(&dto)
+		out = append(out, l2Domain)
+	}
 	return
 }
 
 // GetVlansInL2Domain GETs the vlans in a l2domains by l2domain ID.
 func (c *Controller) GetVlansInl2Domain(id int) (out []vlans.VLAN, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/l2domains/%d/vlans/", id), &struct{}{}, &out)
+	var dtos []vlans.VLANDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/l2domains/%d/vlans/", id), &struct{}{}, &dtos)
+	for _, dto := range dtos {
+		var vlan vlans.VLAN
+		vlan.FromDTO(&dto)
+		out = append(out, vlan)
+	}
 	return
 }
 
 // UpdateL2Domain updates a l2domain by sending a PATCH request.
 func (c *Controller) UpdateL2Domain(in L2Domain) (err error) {
-	err = c.SendRequest("PATCH", "/l2domains/", &in, &struct{}{})
+	err = c.SendRequest("PATCH", "/l2domains/", in.ToDTO(), &struct{}{})
 	return
 }
 

--- a/controllers/subnets/subnets.go
+++ b/controllers/subnets/subnets.go
@@ -12,9 +12,9 @@ import (
 )
 
 // Subnet represents a PHPIPAM subnet.
-type Subnet struct {
+type SubnetDTO struct {
 	// The subnet ID.
-	ID int `json:"id,string,omitempty"`
+	ID phpipam.JSONIntString `json:"id,omitempty"`
 
 	// The subnet address, in dotted quad format (i.e. A.B.C.D).
 	SubnetAddress string `json:"subnet,omitempty"`
@@ -26,22 +26,22 @@ type Subnet struct {
 	Description string `json:"description,omitempty"`
 
 	// The section ID to add the subnet to (required when adding).
-	SectionID int `json:"sectionId,string,omitempty"`
+	SectionID phpipam.JSONIntString `json:"sectionId,omitempty"`
 
 	// The ID of a linked IPv6 subnet.
-	LinkedSubnet int `json:"linked_subnet,string,omitempty"`
+	LinkedSubnet phpipam.JSONIntString `json:"linked_subnet,omitempty"`
 
 	// The ID of the VLAN that this subnet belongs to.
-	VLANID int `json:"vlanId,string,omitempty"`
+	VLANID phpipam.JSONIntString `json:"vlanId,omitempty"`
 
 	// The ID of the VRF this subnet belongs to.
-	VRFID int `json:"vrfId,string,omitempty"`
+	VRFID phpipam.JSONIntString `json:"vrfId,omitempty"`
 
 	// The parent subnet ID if this is a nested subnet.
-	MasterSubnetID int `json:"masterSubnetId,string,omitempty"`
+	MasterSubnetID phpipam.JSONIntString `json:"masterSubnetId,omitempty"`
 
 	// The ID of the nameserver to attache the subnet to.
-	NameserverID int `json:"nameserverId,string,omitempty"`
+	NameserverID phpipam.JSONIntString `json:"nameserverId,omitempty"`
 
 	// The ID and IPs of the nameservers for the subnet
 	Nameservers map[string]interface{} `json:"nameservers,omitempty"`
@@ -64,7 +64,7 @@ type Subnet struct {
 	AllowRequests phpipam.BoolIntString `json:"allowRequests,omitempty"`
 
 	// The ID of the scan agent to use for the subnet.
-	ScanAgent int `json:"scanAgent,string,omitempty"`
+	ScanAgent phpipam.JSONIntString `json:"scanAgent,omitempty"`
 
 	// Controls if the subnet should be included in status checks.
 	PingSubnet phpipam.BoolIntString `json:"pingSubnet,omitempty"`
@@ -82,10 +82,10 @@ type Subnet struct {
 	IsFull phpipam.BoolIntString `json:"isFull,omitempty"`
 
 	// The threshold of the subnet.
-	Threshold int `json:"threshold,string,omitempty"`
+	Threshold phpipam.JSONIntString `json:"threshold,omitempty"`
 
 	// The location index of the subnet.
-	Location int `json:"location,string,omitempty"`
+	Location phpipam.JSONIntString `json:"location,omitempty"`
 
 	// The date of the last edit to this resource.
 	EditDate string `json:"editDate,omitempty"`
@@ -107,6 +107,167 @@ type Subnet struct {
 	ResolveDNS phpipam.BoolIntString `json:"resolveDNS,omitempty"`
 }
 
+type Subnet struct {
+	// The subnet ID.
+	ID int
+
+	// The subnet address, in dotted quad format (i.e. A.B.C.D).
+	SubnetAddress string
+
+	// The subnet's mask in number of bits (i.e. 24).
+	Mask phpipam.JSONIntString
+
+	// A detailed description of the subnet.
+	Description string
+
+	// The section ID to add the subnet to (required when adding).
+	SectionID int
+
+	// The ID of a linked IPv6 subnet.
+	LinkedSubnet int
+
+	// The ID of the VLAN that this subnet belongs to.
+	VLANID int
+
+	// The ID of the VRF this subnet belongs to.
+	VRFID int
+
+	// The parent subnet ID if this is a nested subnet.
+	MasterSubnetID int
+
+	// The ID of the nameserver to attache the subnet to.
+	NameserverID int
+
+	// The ID and IPs of the nameservers for the subnet
+	Nameservers map[string]interface{}
+
+	// true if the name should be displayed in listing instead of the subnet
+	// address.
+	ShowName phpipam.BoolIntString
+
+	// A JSON object, stringified, that represents the permissions for this
+	// section.
+	Permissions string
+
+	// Controls if PTR records should be created for the subnet.
+	DNSRecursive phpipam.BoolIntString
+
+	// Controls if DNS hostname records are displayed.
+	DNSRecords phpipam.BoolIntString
+
+	// Controls if IP requests are allowed for the subnet.
+	AllowRequests phpipam.BoolIntString
+
+	// The ID of the scan agent to use for the subnet.
+	ScanAgent int
+
+	// Controls if the subnet should be included in status checks.
+	PingSubnet phpipam.BoolIntString
+
+	// Controls if new hosts should be discovered for new host scans.
+	DiscoverSubnet phpipam.BoolIntString
+
+	// Controls if we are adding a subnet or folder.
+	IsFolder phpipam.BoolIntString
+
+	// Marks the subnet as permitting allocation of the network and broadcast addresses.
+	IsPool phpipam.BoolIntString
+
+	// Marks the subnet as used.
+	IsFull phpipam.BoolIntString
+
+	// The threshold of the subnet.
+	Threshold int
+
+	// The location index of the subnet.
+	Location int
+
+	// The date of the last edit to this resource.
+	EditDate string
+
+	// Gateway IP and ID of Gateway IP
+	Gateway map[string]interface{}
+
+	// Gateway IP ID
+	GatewayID string
+
+	// A map[string]interface{} of custom fields to set on the resource. Note
+	// that this functionality requires PHPIPAM 1.3 or higher with the "Nest
+	// custom fields" flag set on the specific API integration. If this is not
+	// enabled, this map will be nil on GETs and POSTs and PATCHes with this
+	// field set will fail. Use the explicit custom field functions instead.
+	CustomFields map[string]interface{}
+
+	// Controls enabling resolve DNS function.
+	ResolveDNS phpipam.BoolIntString
+}
+
+func (s *Subnet) FromDTO(subnetDTO *SubnetDTO) {
+	s.ID = int(subnetDTO.ID)
+	s.SubnetAddress = subnetDTO.SubnetAddress
+	s.Mask = subnetDTO.Mask
+	s.Description = subnetDTO.Description
+	s.SectionID = int(subnetDTO.SectionID)
+	s.LinkedSubnet = int(subnetDTO.LinkedSubnet)
+	s.VLANID = int(subnetDTO.VLANID)
+	s.VRFID = int(subnetDTO.VRFID)
+	s.MasterSubnetID = int(subnetDTO.MasterSubnetID)
+	s.NameserverID = int(subnetDTO.NameserverID)
+	s.Nameservers = subnetDTO.Nameservers
+	s.ShowName = subnetDTO.ShowName
+	s.Permissions = subnetDTO.Permissions
+	s.DNSRecursive = subnetDTO.DNSRecursive
+	s.DNSRecords = subnetDTO.DNSRecords
+	s.AllowRequests = subnetDTO.AllowRequests
+	s.ScanAgent = int(subnetDTO.ScanAgent)
+	s.PingSubnet = subnetDTO.PingSubnet
+	s.DiscoverSubnet = subnetDTO.DiscoverSubnet
+	s.IsFolder = subnetDTO.IsFolder
+	s.IsPool = subnetDTO.IsPool
+	s.IsFull = subnetDTO.IsFull
+	s.Threshold = int(subnetDTO.Threshold)
+	s.Location = int(subnetDTO.Location)
+	s.EditDate = subnetDTO.EditDate
+	s.Gateway = subnetDTO.Gateway
+	s.GatewayID = subnetDTO.GatewayID
+	s.CustomFields = subnetDTO.CustomFields
+	s.ResolveDNS = subnetDTO.ResolveDNS
+}
+
+func (s *Subnet) ToDTO() *SubnetDTO {
+	return &SubnetDTO{
+		ID:             phpipam.JSONIntString(s.ID),
+		SubnetAddress:  s.SubnetAddress,
+		Mask:           s.Mask,
+		Description:    s.Description,
+		SectionID:      phpipam.JSONIntString(s.SectionID),
+		LinkedSubnet:   phpipam.JSONIntString(s.LinkedSubnet),
+		VLANID:         phpipam.JSONIntString(s.VLANID),
+		VRFID:          phpipam.JSONIntString(s.VRFID),
+		MasterSubnetID: phpipam.JSONIntString(s.MasterSubnetID),
+		NameserverID:   phpipam.JSONIntString(s.NameserverID),
+		Nameservers:    s.Nameservers,
+		ShowName:       s.ShowName,
+		Permissions:    s.Permissions,
+		DNSRecursive:   s.DNSRecursive,
+		DNSRecords:     s.DNSRecords,
+		AllowRequests:  s.AllowRequests,
+		ScanAgent:      phpipam.JSONIntString(s.ScanAgent),
+		PingSubnet:     s.PingSubnet,
+		DiscoverSubnet: s.DiscoverSubnet,
+		IsFolder:       s.IsFolder,
+		IsPool:         s.IsPool,
+		IsFull:         s.IsFull,
+		Threshold:      phpipam.JSONIntString(s.Threshold),
+		Location:       phpipam.JSONIntString(s.Location),
+		EditDate:       s.EditDate,
+		Gateway:        s.Gateway,
+		GatewayID:      s.GatewayID,
+		CustomFields:   s.CustomFields,
+		ResolveDNS:     s.ResolveDNS,
+	}
+}
+
 // Controller is the base client for the Subnets controller.
 type Controller struct {
 	client.Client
@@ -122,19 +283,21 @@ func NewController(sess *session.Session) *Controller {
 
 // CreateSubnet creates a subnet by sending a POST request.
 func (c *Controller) CreateSubnet(in Subnet) (message string, err error) {
-	err = c.SendRequest("POST", "/subnets/", &in, &message)
+	err = c.SendRequest("POST", "/subnets/", in.ToDTO(), &message)
 	return
 }
 
 // CreateFirstFreeSubnet creates a first free child subnet inside subnet with specified mask by sending a POST request.
 func (c *Controller) CreateFirstFreeSubnet(id int, mask int, in Subnet) (message string, err error) {
-	err = c.SendRequest("POST", fmt.Sprintf("/subnets/%d/first_subnet/%d/", id, mask), &in, &message)
+	err = c.SendRequest("POST", fmt.Sprintf("/subnets/%d/first_subnet/%d/", id, mask), in.ToDTO(), &message)
 	return
 }
 
 // GetSubnetByID GETs a subnet via its ID.
 func (c *Controller) GetSubnetByID(id int) (out Subnet, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/subnets/%d/", id), &struct{}{}, &out)
+	var dto SubnetDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/subnets/%d/", id), &struct{}{}, &dto)
+	out.FromDTO(&dto)
 	return
 }
 
@@ -146,12 +309,24 @@ func (c *Controller) GetSubnetByID(id int) (out Subnet, err error) {
 // will not return multiple results, and using the CIDR of a master subnet will
 // return that subnet only.
 func (c *Controller) GetSubnetsByCIDR(cidr string) (out []Subnet, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/subnets/cidr/%s/", cidr), &struct{}{}, &out)
+	var dtos []SubnetDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/subnets/cidr/%s/", cidr), &struct{}{}, &dtos)
+	for _, dto := range dtos {
+		var subnet Subnet
+		subnet.FromDTO(&dto)
+		out = append(out, subnet)
+	}
 	return
 }
 
 func (c *Controller) GetSubnetsByCIDRAndSection(cidr string, section_id int) (out []Subnet, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/subnets/cidr/%s/?filter_by=sectionId&filter_value=%d", cidr, section_id), &struct{}{}, &out)
+	var dtos []SubnetDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/subnets/cidr/%s/?filter_by=sectionId&filter_value=%d", cidr, section_id), &struct{}{}, &dtos)
+	for _, dto := range dtos {
+		var subnet Subnet
+		subnet.FromDTO(&dto)
+		out = append(out, subnet)
+	}
 	return
 }
 
@@ -176,7 +351,13 @@ func (c *Controller) GetFirstFreeAddress(id int) (out string, err error) {
 // GetAddressesInSubnet GETs the IP addresses for a specific subnet, via a
 // supplied subnet ID.
 func (c *Controller) GetAddressesInSubnet(id int) (out []addresses.Address, err error) {
-	err = c.SendRequest("GET", fmt.Sprintf("/subnets/%d/addresses/", id), &struct{}{}, &out)
+	var dtos []addresses.AddressDTO
+	err = c.SendRequest("GET", fmt.Sprintf("/subnets/%d/addresses/", id), &struct{}{}, &dtos)
+	for _, dto := range dtos {
+		var address addresses.Address
+		address.FromDTO(&dto)
+		out = append(out, address)
+	}
 	return
 }
 
@@ -200,7 +381,7 @@ func (c *Controller) GetSubnetCustomFields(id int) (out map[string]interface{}, 
 // grow, or renumber a subnet, you need to use other methods that are currently
 // not implemented in this SDK. See the API spec for more details.
 func (c *Controller) UpdateSubnet(in Subnet) (message string, err error) {
-	err = c.SendRequest("PATCH", "/subnets/", &in, &message)
+	err = c.SendRequest("PATCH", "/subnets/", in.ToDTO(), &message)
 	return
 }
 

--- a/phpipam/phpipam.go
+++ b/phpipam/phpipam.go
@@ -103,7 +103,12 @@ func (bis BoolIntString) MarshalJSON() ([]byte, error) {
 func (bis *BoolIntString) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
-		return err
+		// If unmarshalling to a string fails, try unmarshalling to an int.
+		var i int
+		if err := json.Unmarshal(b, &i); err != nil {
+			return err
+		}
+		s = strconv.Itoa(int(i))
 	}
 	switch s {
 	case "0", "":
@@ -133,19 +138,25 @@ func (jis JSONIntString) MarshalJSON() ([]byte, error) {
 func (jis *JSONIntString) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-	if s == "" {
-		*jis = 0
-	} else {
-		i, err := strconv.Atoi(s)
-		if err != nil {
-			return &json.UnmarshalTypeError{
-				Value: "int",
-				Type:  reflect.ValueOf(s).Type(),
-			}
+		// If unmarshalling to a string fails, try unmarshalling to an int.
+		var i int
+		if err := json.Unmarshal(b, &i); err != nil {
+			return err
 		}
 		*jis = JSONIntString(i)
+	} else {
+		if s == "" {
+			*jis = 0
+		} else {
+			i, err := strconv.Atoi(s)
+			if err != nil {
+				return &json.UnmarshalTypeError{
+					Value: "int",
+					Type:  reflect.ValueOf(s).Type(),
+				}
+			}
+			*jis = JSONIntString(i)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## What

- Modify struct types to support PHP 8 (and <8 as well).
- Basically, this PR proposes to split the struct types used between the SDK and phpIPAM, from the ones used between the provider and the SDK.
  - Example: `SDK user` --- `{Address}`  ---> `SDK` --- `{AddressDTO}` ---> `phpIPAM`
 - This should not be a breaking change
 
## Why

- Since PHP 8, integers and floats in result sets will now be returned using native PHP types instead of strings when using emulated prepared statements.
- This PR adds the necessary logic to allow SDK to communicate with phpIPAM running on version 8 and below.

## Ref

- https://github.com/phpipam/phpipam/issues/4043
- https://github.com/lord-kyron/terraform-provider-phpipam/issues/84

### Notes

- Had to change the tests to include the prefix `custom_` in all custom fields, to match default phpIPAM behavior. If needed, I can push that commit as well.

## Tests

### Unit

```sh
go test -v ./...
```

<details><summary>Output</summary>
<p>

```sh
?       github.com/pavel-z1/phpipam-sdk-go      [no test files]
?       github.com/pavel-z1/phpipam-sdk-go/controllers/l2domains        [no test files]
=== RUN   TestCreateAddress
--- PASS: TestCreateAddress (0.00s)
=== RUN   TestGetAddressByID
--- PASS: TestGetAddressByID (0.00s)
=== RUN   TestGetAddressesByIP
--- PASS: TestGetAddressesByIP (0.00s)
=== RUN   TestGetAddressesByIpInSubnet
--- PASS: TestGetAddressesByIpInSubnet (0.00s)
=== RUN   TestGetAddressCustomFieldsSchema
--- PASS: TestGetAddressCustomFieldsSchema (0.01s)
=== RUN   TestUpdateAddress
--- PASS: TestUpdateAddress (0.00s)
=== RUN   TestDeleteAddress
--- PASS: TestDeleteAddress (0.00s)
=== RUN   TestAccAddressCRUD
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccAddressCRUD (0.00s)
=== RUN   TestAccGetAddressCustomFieldsSchema
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccGetAddressCustomFieldsSchema (0.00s)
=== RUN   TestAccAddressCustomFieldUpdateRead
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccAddressCustomFieldUpdateRead (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/addresses        0.019s
=== RUN   TestListSections
--- PASS: TestListSections (0.00s)
=== RUN   TestCreateSection
--- PASS: TestCreateSection (0.00s)
=== RUN   TestGetSectionByID
--- PASS: TestGetSectionByID (0.01s)
=== RUN   TestGetSectionByName
--- PASS: TestGetSectionByName (0.00s)
=== RUN   TestGetSubnetsInSection
--- PASS: TestGetSubnetsInSection (0.00s)
=== RUN   TestUpdateSection
--- PASS: TestUpdateSection (0.00s)
=== RUN   TestDeleteSection
--- PASS: TestDeleteSection (0.00s)
=== RUN   TestAccSectionsCRUD
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccSectionsCRUD (0.00s)
=== RUN   TestAccGetSubnetsInSection
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccGetSubnetsInSection (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/sections 0.014s
=== RUN   TestCreateSubnet
--- PASS: TestCreateSubnet (0.00s)
=== RUN   TestCreateFirstFreeSubnet
--- PASS: TestCreateFirstFreeSubnet (0.00s)
=== RUN   TestGetSubnetByID
--- PASS: TestGetSubnetByID (0.00s)
=== RUN   TestGetSubnetsByCIDR
--- PASS: TestGetSubnetsByCIDR (0.00s)
=== RUN   TestGetFirstFreeSubnet
--- PASS: TestGetFirstFreeSubnet (0.00s)
=== RUN   TestGetFirstFreeAddress
--- PASS: TestGetFirstFreeAddress (0.00s)
=== RUN   TestGetAddressesInSubnet
--- PASS: TestGetAddressesInSubnet (0.00s)
=== RUN   TestGetSubnetCustomFieldsSchema
--- PASS: TestGetSubnetCustomFieldsSchema (0.00s)
=== RUN   TestUpdateSubnet
--- PASS: TestUpdateSubnet (0.00s)
=== RUN   TestDeleteSubnet
--- PASS: TestDeleteSubnet (0.00s)
=== RUN   TestAccSubnetCRUD
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccSubnetCRUD (0.00s)
=== RUN   TestAccGetAddressesInSubnet
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccGetAddressesInSubnet (0.00s)
=== RUN   TestAccGetSubnetCustomFieldsSchema
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccGetSubnetCustomFieldsSchema (0.00s)
=== RUN   TestAccSubnetCustomFieldUpdateRead
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccSubnetCustomFieldUpdateRead (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/subnets  0.014s
=== RUN   TestCreateVLAN
--- PASS: TestCreateVLAN (0.00s)
=== RUN   TestGetVLANByID
--- PASS: TestGetVLANByID (0.00s)
=== RUN   TestGetVLANsByNumber
--- PASS: TestGetVLANsByNumber (0.00s)
=== RUN   TestGetVLANCustomFieldsSchema
--- PASS: TestGetVLANCustomFieldsSchema (0.00s)
=== RUN   TestUpdateVLAN
--- PASS: TestUpdateVLAN (0.00s)
=== RUN   TestDeleteVLAN
--- PASS: TestDeleteVLAN (0.00s)
=== RUN   TestAccVLANCRUD
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccVLANCRUD (0.00s)
=== RUN   TestAccGetVLANCustomFieldsSchema
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccGetVLANCustomFieldsSchema (0.00s)
=== RUN   TestAccVLANCustomFieldUpdateRead
    testacc.go:12: Skipping integration test as TESTACC is not set.
--- SKIP: TestAccVLANCustomFieldUpdateRead (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/vlans    0.012s
=== RUN   TestPHPIPAMDefaultConfigProviderWithEnv
--- PASS: TestPHPIPAMDefaultConfigProviderWithEnv (0.00s)
=== RUN   TestPHPIPAMDefaultConfigProviderNoEnv
--- PASS: TestPHPIPAMDefaultConfigProviderNoEnv (0.00s)
=== RUN   TestBoolIntStringUnmarshalJSONTrue
--- PASS: TestBoolIntStringUnmarshalJSONTrue (0.00s)
=== RUN   TestBoolIntStringUnmarshalJSONFalse
--- PASS: TestBoolIntStringUnmarshalJSONFalse (0.00s)
=== RUN   TestBoolIntStringUnmarshalJSONError
--- PASS: TestBoolIntStringUnmarshalJSONError (0.00s)
=== RUN   TestBoolIntStringMarshalJSONTrue
--- PASS: TestBoolIntStringMarshalJSONTrue (0.00s)
=== RUN   TestBoolIntStringMarshalJSONFalse
--- PASS: TestBoolIntStringMarshalJSONFalse (0.00s)
=== RUN   TestJSONIntStringUnmarshalJSONZeroEmpty
--- PASS: TestJSONIntStringUnmarshalJSONZeroEmpty (0.00s)
=== RUN   TestJSONIntStringUnmarshalJSONZeroNumber
--- PASS: TestJSONIntStringUnmarshalJSONZeroNumber (0.00s)
=== RUN   TestJSONIntStringUnmarshalJSONNonZeroNumber
--- PASS: TestJSONIntStringUnmarshalJSONNonZeroNumber (0.00s)
=== RUN   TestJSONIntStringUnmarshalJSONError
--- PASS: TestJSONIntStringUnmarshalJSONError (0.00s)
=== RUN   TestJSONIntStringMarshalJSONZero
--- PASS: TestJSONIntStringMarshalJSONZero (0.00s)
=== RUN   TestJSONIntStringMarshalJSONOmitEmpty
--- PASS: TestJSONIntStringMarshalJSONOmitEmpty (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam      0.003s
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginSessionSuccess
--- PASS: TestLoginSessionSuccess (0.00s)
=== RUN   TestLoginSessionError
--- PASS: TestLoginSessionError (0.00s)
=== RUN   TestSendRequestSuccess
--- PASS: TestSendRequestSuccess (0.00s)
=== RUN   TestSendRequestError
--- PASS: TestSendRequestError (0.00s)
=== RUN   TestGetCustomFieldsSchema
--- PASS: TestGetCustomFieldsSchema (0.00s)
=== RUN   TestUpdateCustomFieldsRequest
--- PASS: TestUpdateCustomFieldsRequest (0.00s)
=== RUN   TestUpdateCustomFieldsRequestIllegalField
--- PASS: TestUpdateCustomFieldsRequestIllegalField (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/client       0.007s
?       github.com/pavel-z1/phpipam-sdk-go/testacc      [no test files]
=== RUN   TestRequestSendSuccess
--- PASS: TestRequestSendSuccess (0.00s)
=== RUN   TestRequestSendError
--- PASS: TestRequestSendError (0.00s)
=== RUN   TestRequestSendNonJSONError
--- PASS: TestRequestSendNonJSONError (0.00s)
=== RUN   TestRequestSendProtocolError
--- PASS: TestRequestSendProtocolError (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/request      0.005s
=== RUN   TestNewSession
--- PASS: TestNewSession (0.00s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/session      0.002s
```


</p>
</details>

### Acceptance

```sh
TESTACC=1 go test -p 1 -v ./... -run="TestAcc"
```

<details><summary>Output</summary>
<p>

```sh
?       github.com/pavel-z1/phpipam-sdk-go      [no test files]
=== RUN   TestAccAddressCRUD
2024/02/26 13:04:18 Note: Not testing nested custom fields as TESTACC_CUSTOM_NESTED is not set
--- PASS: TestAccAddressCRUD (0.30s)
=== RUN   TestAccGetAddressCustomFieldsSchema
--- PASS: TestAccGetAddressCustomFieldsSchema (0.08s)
=== RUN   TestAccAddressCustomFieldUpdateRead
--- PASS: TestAccAddressCustomFieldUpdateRead (4.75s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/addresses        5.132s
?       github.com/pavel-z1/phpipam-sdk-go/controllers/l2domains        [no test files]
=== RUN   TestAccSectionsCRUD
--- PASS: TestAccSectionsCRUD (0.30s)
=== RUN   TestAccGetSubnetsInSection
2024/02/26 13:04:24 Note: Not testing nested custom fields as TESTACC_CUSTOM_NESTED is not set
--- PASS: TestAccGetSubnetsInSection (0.07s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/sections 0.373s
=== RUN   TestAccSubnetCRUD
2024/02/26 13:04:24 Note: Not testing nested custom fields as TESTACC_CUSTOM_NESTED is not set
--- PASS: TestAccSubnetCRUD (0.27s)
=== RUN   TestAccGetAddressesInSubnet
2024/02/26 13:04:24 Note: Not testing nested custom fields as TESTACC_CUSTOM_NESTED is not set
--- PASS: TestAccGetAddressesInSubnet (0.09s)
=== RUN   TestAccGetSubnetCustomFieldsSchema
--- PASS: TestAccGetSubnetCustomFieldsSchema (0.07s)
=== RUN   TestAccSubnetCustomFieldUpdateRead
--- PASS: TestAccSubnetCustomFieldUpdateRead (2.92s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/subnets  3.349s
=== RUN   TestAccVLANCRUD
2024/02/26 13:04:28 Note: Not testing nested custom fields as TESTACC_CUSTOM_NESTED is not set
--- PASS: TestAccVLANCRUD (0.27s)
=== RUN   TestAccGetVLANCustomFieldsSchema
--- PASS: TestAccGetVLANCustomFieldsSchema (0.06s)
=== RUN   TestAccVLANCustomFieldUpdateRead
--- PASS: TestAccVLANCustomFieldUpdateRead (0.49s)
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/controllers/vlans    0.828s
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam      0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/client       0.003s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/request      0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/session      0.001s [no tests to run]
?       github.com/pavel-z1/phpipam-sdk-go/testacc      [no test files]
```

</p>
</details>


### Acceptance with custom nested

Fails, but running the same command against the last release (v0.1.8) yields the same result.

```sh
TESTACC_CUSTOM_NESTED=1 TESTACC=1 go test -p 1 -v ./... -run="TestAcc"
```

<details><summary>Output</summary>
<p>

```sh
?       github.com/pavel-z1/phpipam-sdk-go      [no test files]
=== RUN   TestAccAddressCRUD
    addresses_test.go:423: ReadByIP: Could not find address addresses.Address{ID:11, SubnetID:3, IPAddress:"10.10.1.10", IsGateway:false, Description:"foobar", Hostname:"", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":"foobar", "custom_CustomTestAddresses2":interface {}(nil)}} in []addresses.Address{addresses.Address{ID:11, SubnetID:3, IPAddress:"10.10.1.10", IsGateway:false, Description:"foobar", Hostname:"", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":"foobar"}}}
--- FAIL: TestAccAddressCRUD (0.13s)
=== RUN   TestAccGetAddressCustomFieldsSchema
--- PASS: TestAccGetAddressCustomFieldsSchema (0.07s)
=== RUN   TestAccAddressCustomFieldUpdateRead
    testacc.go:20: Skipping non-nested custom field test because TESTACC_CUSTOM_NESTED is set
--- SKIP: TestAccAddressCustomFieldUpdateRead (0.00s)
FAIL
FAIL    github.com/pavel-z1/phpipam-sdk-go/controllers/addresses        0.208s
?       github.com/pavel-z1/phpipam-sdk-go/controllers/l2domains        [no test files]
=== RUN   TestAccSectionsCRUD
--- PASS: TestAccSectionsCRUD (0.29s)
=== RUN   TestAccGetSubnetsInSection
    sections_test.go:708: Expected ([]subnets.Subnet) (len=5 cap=5) {
         (subnets.Subnet) {
          ID: (int) 5,
          SubnetAddress: (string) (len=7) "0.0.0.0",
          Mask: (phpipam.JSONIntString) 0,
          Description: (string) (len=9) "My folder",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 0,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) false,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) false,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) true,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) (len=2) {
           (string) (len=24) "custom_CustomTestSubnets": (interface {}) <nil>,
           (string) (len=25) "custom_CustomTestSubnets2": (interface {}) <nil>
          },
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 2,
          SubnetAddress: (string) (len=9) "10.10.0.0",
          Mask: (phpipam.JSONIntString) 16,
          Description: (string) (len=18) "Business customers",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 0,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) true,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) (len=2) {
           (string) (len=24) "custom_CustomTestSubnets": (interface {}) <nil>,
           (string) (len=25) "custom_CustomTestSubnets2": (interface {}) <nil>
          },
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 3,
          SubnetAddress: (string) (len=9) "10.10.1.0",
          Mask: (phpipam.JSONIntString) 24,
          Description: (string) (len=10) "Customer 1",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 2,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) true,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) (len=2) {
           (string) (len=24) "custom_CustomTestSubnets": (interface {}) <nil>,
           (string) (len=25) "custom_CustomTestSubnets2": (interface {}) <nil>
          },
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 4,
          SubnetAddress: (string) (len=9) "10.10.2.0",
          Mask: (phpipam.JSONIntString) 24,
          Description: (string) (len=10) "Customer 2",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 2,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) true,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) (len=2) {
           (string) (len=24) "custom_CustomTestSubnets": (interface {}) <nil>,
           (string) (len=25) "custom_CustomTestSubnets2": (interface {}) <nil>
          },
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 6,
          SubnetAddress: (string) (len=10) "10.65.22.0",
          Mask: (phpipam.JSONIntString) 24,
          Description: (string) (len=10) "DHCP range",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 5,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) false,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) (len=2) {
           (string) (len=24) "custom_CustomTestSubnets": (interface {}) <nil>,
           (string) (len=25) "custom_CustomTestSubnets2": (interface {}) <nil>
          },
          ResolveDNS: (phpipam.BoolIntString) false
         }
        }
        , got ([]subnets.Subnet) (len=5 cap=9) {
         (subnets.Subnet) {
          ID: (int) 5,
          SubnetAddress: (string) (len=7) "0.0.0.0",
          Mask: (phpipam.JSONIntString) 0,
          Description: (string) (len=9) "My folder",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 0,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) false,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) false,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) true,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) <nil>,
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 2,
          SubnetAddress: (string) (len=9) "10.10.0.0",
          Mask: (phpipam.JSONIntString) 16,
          Description: (string) (len=18) "Business customers",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 0,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) true,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) <nil>,
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 3,
          SubnetAddress: (string) (len=9) "10.10.1.0",
          Mask: (phpipam.JSONIntString) 24,
          Description: (string) (len=10) "Customer 1",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 2,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) true,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) <nil>,
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 4,
          SubnetAddress: (string) (len=9) "10.10.2.0",
          Mask: (phpipam.JSONIntString) 24,
          Description: (string) (len=10) "Customer 2",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 2,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) true,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) <nil>,
          ResolveDNS: (phpipam.BoolIntString) false
         },
         (subnets.Subnet) {
          ID: (int) 6,
          SubnetAddress: (string) (len=10) "10.65.22.0",
          Mask: (phpipam.JSONIntString) 24,
          Description: (string) (len=10) "DHCP range",
          SectionID: (int) 1,
          LinkedSubnet: (int) 0,
          VLANID: (int) 0,
          VRFID: (int) 0,
          MasterSubnetID: (int) 5,
          NameserverID: (int) 0,
          Nameservers: (map[string]interface {}) <nil>,
          ShowName: (phpipam.BoolIntString) true,
          Permissions: (string) (len=17) "{\"3\":\"1\",\"2\":\"2\"}",
          DNSRecursive: (phpipam.BoolIntString) false,
          DNSRecords: (phpipam.BoolIntString) false,
          AllowRequests: (phpipam.BoolIntString) false,
          ScanAgent: (int) 0,
          PingSubnet: (phpipam.BoolIntString) false,
          DiscoverSubnet: (phpipam.BoolIntString) false,
          IsFolder: (phpipam.BoolIntString) false,
          IsPool: (phpipam.BoolIntString) false,
          IsFull: (phpipam.BoolIntString) false,
          Threshold: (int) 0,
          Location: (int) 0,
          EditDate: (string) "",
          Gateway: (map[string]interface {}) <nil>,
          GatewayID: (string) "",
          CustomFields: (map[string]interface {}) <nil>,
          ResolveDNS: (phpipam.BoolIntString) false
         }
        }
--- FAIL: TestAccGetSubnetsInSection (0.47s)
FAIL
FAIL    github.com/pavel-z1/phpipam-sdk-go/controllers/sections 0.765s
=== RUN   TestAccSubnetCRUD
    subnets_test.go:742: ReadByCIDR: Could not find subnet subnets.Subnet{ID:7, SubnetAddress:"10.10.3.0", Mask:24, Description:"", SectionID:1, LinkedSubnet:0, VLANID:0, VRFID:0, MasterSubnetID:2, NameserverID:0, Nameservers:map[string]interface {}(nil), ShowName:false, Permissions:"{\"3\":\"1\",\"2\":\"2\"}", DNSRecursive:false, DNSRecords:false, AllowRequests:false, ScanAgent:0, PingSubnet:false, DiscoverSubnet:false, IsFolder:false, IsPool:false, IsFull:false, Threshold:0, Location:0, EditDate:"", Gateway:map[string]interface {}(nil), GatewayID:"", CustomFields:map[string]interface {}{"custom_CustomTestSubnets":"foobar", "custom_CustomTestSubnets2":interface {}(nil)}, ResolveDNS:false} in []subnets.Subnet{subnets.Subnet{ID:7, SubnetAddress:"10.10.3.0", Mask:24, Description:"", SectionID:1, LinkedSubnet:0, VLANID:0, VRFID:0, MasterSubnetID:2, NameserverID:0, Nameservers:map[string]interface {}(nil), ShowName:false, Permissions:"{\"3\":\"1\",\"2\":\"2\"}", DNSRecursive:false, DNSRecords:false, AllowRequests:false, ScanAgent:0, PingSubnet:false, DiscoverSubnet:false, IsFolder:false, IsPool:false, IsFull:false, Threshold:0, Location:0, EditDate:"", Gateway:map[string]interface {}(nil), GatewayID:"", CustomFields:map[string]interface {}{"custom_CustomTestSubnets":"foobar"}, ResolveDNS:false}}
--- FAIL: TestAccSubnetCRUD (0.11s)
=== RUN   TestAccGetAddressesInSubnet
    subnets_test.go:876: Expected []addresses.Address{addresses.Address{ID:1, SubnetID:3, IPAddress:"10.10.1.3", IsGateway:false, Description:"Server1", Hostname:"server1.cust1.local", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":interface {}(nil), "custom_CustomTestAddresses2":interface {}(nil)}}, addresses.Address{ID:2, SubnetID:3, IPAddress:"10.10.1.4", IsGateway:false, Description:"Server2", Hostname:"server2.cust1.local", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":interface {}(nil), "custom_CustomTestAddresses2":interface {}(nil)}}, addresses.Address{ID:3, SubnetID:3, IPAddress:"10.10.1.5", IsGateway:false, Description:"Server3", Hostname:"server3.cust1.local", MACAddress:"", Owner:"", Tag:3, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":interface {}(nil), "custom_CustomTestAddresses2":interface {}(nil)}}, addresses.Address{ID:4, SubnetID:3, IPAddress:"10.10.1.6", IsGateway:false, Description:"Server4", Hostname:"server4.cust1.local", MACAddress:"", Owner:"", Tag:3, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":interface {}(nil), "custom_CustomTestAddresses2":interface {}(nil)}}, addresses.Address{ID:5, SubnetID:3, IPAddress:"10.10.1.245", IsGateway:false, Description:"Gateway", Hostname:"", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":interface {}(nil), "custom_CustomTestAddresses2":interface {}(nil)}}}, got []addresses.Address{addresses.Address{ID:1, SubnetID:3, IPAddress:"10.10.1.3", IsGateway:false, Description:"Server1", Hostname:"server1.cust1.local", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}(nil)}, addresses.Address{ID:2, SubnetID:3, IPAddress:"10.10.1.4", IsGateway:false, Description:"Server2", Hostname:"server2.cust1.local", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}(nil)}, addresses.Address{ID:3, SubnetID:3, IPAddress:"10.10.1.5", IsGateway:false, Description:"Server3", Hostname:"server3.cust1.local", MACAddress:"", Owner:"", Tag:3, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}(nil)}, addresses.Address{ID:4, SubnetID:3, IPAddress:"10.10.1.6", IsGateway:false, Description:"Server4", Hostname:"server4.cust1.local", MACAddress:"", Owner:"", Tag:3, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}(nil)}, addresses.Address{ID:11, SubnetID:3, IPAddress:"10.10.1.10", IsGateway:false, Description:"foobar", Hostname:"", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestAddresses":"foobar"}}, addresses.Address{ID:5, SubnetID:3, IPAddress:"10.10.1.245", IsGateway:false, Description:"Gateway", Hostname:"", MACAddress:"", Owner:"", Tag:2, PTRIgnore:false, PTRRecordID:0, DeviceID:0, Port:"", Note:"", LastSeen:"1970-01-01 00:00:01", ExcludePing:false, EditDate:"", CustomFields:map[string]interface {}(nil)}}
--- FAIL: TestAccGetAddressesInSubnet (0.07s)
=== RUN   TestAccGetSubnetCustomFieldsSchema
--- PASS: TestAccGetSubnetCustomFieldsSchema (0.07s)
=== RUN   TestAccSubnetCustomFieldUpdateRead
    testacc.go:20: Skipping non-nested custom field test because TESTACC_CUSTOM_NESTED is set
--- SKIP: TestAccSubnetCustomFieldUpdateRead (0.00s)
FAIL
FAIL    github.com/pavel-z1/phpipam-sdk-go/controllers/subnets  0.241s
=== RUN   TestAccVLANCRUD
    vlans_test.go:338: ReadByNumber: Could not find vlan vlans.VLAN{ID:3, DomainID:1, Name:"foolan", Number:1000, Description:"", EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestVLANs":"foobar", "custom_CustomTestVLANs2":interface {}(nil)}} in []vlans.VLAN{vlans.VLAN{ID:3, DomainID:1, Name:"foolan", Number:1000, Description:"", EditDate:"", CustomFields:map[string]interface {}{"custom_CustomTestVLANs":"foobar"}}}
--- FAIL: TestAccVLANCRUD (0.10s)
=== RUN   TestAccGetVLANCustomFieldsSchema
--- PASS: TestAccGetVLANCustomFieldsSchema (0.07s)
=== RUN   TestAccVLANCustomFieldUpdateRead
    testacc.go:20: Skipping non-nested custom field test because TESTACC_CUSTOM_NESTED is set
--- SKIP: TestAccVLANCustomFieldUpdateRead (0.00s)
FAIL
FAIL    github.com/pavel-z1/phpipam-sdk-go/controllers/vlans    0.168s
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam      0.001s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/client       0.003s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/request      0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/pavel-z1/phpipam-sdk-go/phpipam/session      0.001s [no tests to run]
?       github.com/pavel-z1/phpipam-sdk-go/testacc      [no test files]
FAIL
make: *** [Makefile:7: testacc] Error 1
```

</p>
</details> 